### PR TITLE
[release-2.9] Build with Go 1.20

### DIFF
--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -1,6 +1,6 @@
 # Copyright Contributors to the Open Cluster Management project
 
-FROM registry.ci.openshift.org/stolostron/builder:go1.18-linux AS builder
+FROM registry.ci.openshift.org/stolostron/builder:go1.20-linux AS builder
 
 WORKDIR /workspace
 COPY . .


### PR DESCRIPTION
Builds are failing in the `release-2.9` with some weird errors in the SonarCloud step.

The error looks like this:

```
16:21:58.554 ERROR: Cannot save config file 'FileBasedConfig[/.config/jgit/config]'
java.io.IOException: Creating directories for /.config/jgit failed
	at org.eclipse.jgit.util.FileUtils.mkdirs(FileUtils.java:413)
	at org.eclipse.jgit.internal.storage.file.LockFile.lock(LockFile.java:140)
	at org.eclipse.jgit.storage.file.FileBasedConfig.save(FileBasedConfig.java:184)
	at org.eclipse.jgit.util.FS$FileStoreAttributes.saveToConfig(FS.java:766)
	at org.eclipse.jgit.util.FS$FileStoreAttributes.lambda$5(FS.java:448)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at java.base/java.lang.Thread.run(Unknown Source)
```

Raw build logs at: https://storage.googleapis.com/origin-ci-test/logs/branch-ci-stolostron-kube-state-metrics-release-2.9-sonar-post-submit/1722287886541262848/build-log.txt

Release update at https://github.com/openshift/release/pull/45458.