### PR TITLE
Only build e2e files when a tag with same name is provided

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -166,7 +166,7 @@ echo "kube-state-metrics is up and running"
 
 echo "start e2e test for kube-state-metrics"
 KSMURL='http://localhost:8001/api/v1/namespaces/kube-system/services/kube-state-metrics:http-metrics/proxy'
-go test -v ./tests/e2e/ --ksmurl=${KSMURL}
+go test -tags e2e -v ./tests/e2e/ --ksmurl=${KSMURL}
 
 # TODO: re-implement the following test cases in Go with the goal of removing this file.
 echo "access kube-state-metrics metrics endpoint"

--- a/tests/e2e/framework.go
+++ b/tests/e2e/framework.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 

--- a/tests/e2e/main_test.go
+++ b/tests/e2e/main_test.go
@@ -1,3 +1,6 @@
+//go:build e2e
+// +build e2e
+
 /*
 Copyright 2019 The Kubernetes Authors All rights reserved.
 
@@ -5,7 +8,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,7 +16,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
 package e2e
 
 import (


### PR DESCRIPTION
The build harness is running tests with `go test [...] ./...` (see the targets [sonar/go/prow](https://github.com/stolostron/build-harness-extensions/blob/2ce1b35c0098a407dda410ea9dcd66a7263b68b7/modules/sonar/Makefile#L30C51-L30C51) and [sonar/go](https://github.com/stolostron/build-harness-extensions/blob/2ce1b35c0098a407dda410ea9dcd66a7263b68b7/modules/sonar/Makefile#L10), among others). This ends up building and running e2e tests which are supposed to be executed only through the script in `tests/e2e.sh`. 

This PR: 

* Puts the e2e test files behind a build flag named `e2e`.
* Updates the `tests/e2e.sh` script to run the tests using those flags.

This should clear all the remaining SonarCloud complaints on the project, which is about a failing test.