### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kube-state-metrics-acm-214

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -20,7 +20,8 @@ USER nobody
 ENTRYPOINT ["/usr/bin/kube-state-metrics"]
 
 LABEL com.redhat.component="kube-state-metrics" \
-name="kube-state-metrics" \
+name="rhacm2/kube-state-metrics-rhel9" \
+cpe="cpe:/a:redhat:acm:2.14::el9" \
 summary="kube-state-metrics" \
 io.openshift.expose-services="" \
 io.openshift.tags="data,images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
