### PR TITLE
Set UID instead of username

### DIFF
--- a/Containerfile.operator
+++ b/Containerfile.operator
@@ -16,7 +16,7 @@ LABEL io.k8s.display-name="kube-state-metrics" \
       summary="This is a component that exposes metrics about Kubernetes objects."
 
 COPY --from=builder /workspace/kube-state-metrics  /usr/bin/kube-state-metrics
-USER nobody
+USER 1001
 ENTRYPOINT ["/usr/bin/kube-state-metrics"]
 
 LABEL com.redhat.component="kube-state-metrics" \

--- a/Dockerfile.prow
+++ b/Dockerfile.prow
@@ -16,5 +16,5 @@ LABEL io.k8s.display-name="kube-state-metrics" \
       summary="This is a component that exposes metrics about Kubernetes objects."
 
 COPY --from=builder /workspace/kube-state-metrics  /usr/bin/kube-state-metrics
-USER nobody
+USER 1001
 ENTRYPOINT ["/usr/bin/kube-state-metrics"]


### PR DESCRIPTION
Fixes the following which occurs in MCOA on non-ocp clusters.
```
CreateContainerConfigError: “container has runAsNonRoot and image has non-numeric user (nobody),  cannot verify user is non-root”
```