### PR TITLE
Add Dockerfile.art for ART/Brew build migration

### DIFF
--- a/Dockerfile.art
+++ b/Dockerfile.art
@@ -1,0 +1,31 @@
+# Copyright Contributors to the Open Cluster Management project
+# Licensed under the Apache License 2.0
+
+FROM registry-proxy.engineering.redhat.com/rh-osbs/openshift-golang-builder:v1.25.8 AS builder
+
+WORKDIR /workspace
+COPY . .
+ENV GOFLAGS="-mod=mod"
+# RUN GO_FLAGS="" go build --installsuffix cgo
+RUN CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime make -f Makefile.prow build-local
+
+FROM registry-proxy.engineering.redhat.com/ubi9/ubi-minimal:latest
+
+LABEL io.k8s.display-name="kube-state-metrics" \
+      io.k8s.description="This is a component that exposes metrics about Kubernetes objects." \
+      summary="This is a component that exposes metrics about Kubernetes objects."
+
+COPY --from=builder /workspace/kube-state-metrics  /usr/bin/kube-state-metrics
+USER 1001
+ENTRYPOINT ["/usr/bin/kube-state-metrics"]
+
+LABEL com.redhat.component="kube-state-metrics" \
+name="rhacm2/kube-state-metrics-rhel9" \
+cpe="cpe:/a:redhat:acm:2.16::el9" \
+summary="kube-state-metrics" \
+io.openshift.expose-services="" \
+io.openshift.tags="data,images" \
+io.k8s.display-name="kube-state-metrics" \
+maintainer="" \
+description="kube-state-metrics" \
+io.k8s.description="kube-state-metrics"


### PR DESCRIPTION
HYPBLD-847: ACM 2.16: Create Dockerfile.art + ocp-build-data config
https://redhat.atlassian.net/browse/HYPBLD-847

Create the build configuration required for ART to build ACM 2.16 components.

Dockerfile.art files (50 repos):                                                                     
- Create Dockerfile.art in each ACM repo on release-2.16 branch                                      
- Use existing Dockerfile.rhtap as starting point                                                    
- Change registry to registry-proxy.engineering.redhat.com
- Add FIPS flags (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)                                     
Note: multiclusterhub-operator uses brew.registry — needs manual FROM line conversion              

Signed-off-by: Brian Smith (briansmi@redhat.com)