### PR TITLE
Add e2e tests in kube-state-metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
     - main
-    - release*
+    - release-*
     tags:
     - v1.*
     - v2.*
   pull_request:
     branches:
     - main
-    - release*
+    - release-*
 
 permissions:
   contents: read
@@ -43,6 +43,7 @@ jobs:
         make lint
 
   ci-validate-manifests:
+    if: false
     name: ci-validate-manifests
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +78,7 @@ jobs:
         make validate-modules
 
   ci-validate-docs:
+    if: false
     name: ci-validate-docs
     runs-on: ubuntu-latest
     steps:
@@ -154,6 +156,7 @@ jobs:
         EOL
 
   ci-benchmark-tests-release:
+    if: false
     name: ci-benchmark-tests-releasebranch
     runs-on: ubuntu-latest
     steps:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,7 +3,8 @@
     "**/*.md"
   ],
   "ignores": [
-    "vendor/**"
+    "vendor/**",
+    ".cve-fix/**"
   ],
   // ToDo: Following rules can't be fixed automatically. They should be enabled when fixed.
   "config": {


### PR DESCRIPTION
MR to integrate upstream CI workflow for kube-state-metrics into our fork, along with changes added to satisfy linters.
Resolves [ACM-34821](https://redhat.atlassian.net/browse/ACM-34821)

[ACM-34821]: https://redhat.atlassian.net/browse/ACM-34821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ