### PR TITLE
Backport CI Testing To Release-2.17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches:
     - main
-    - release*
+    - release-*
     tags:
     - v1.*
     - v2.*
   pull_request:
     branches:
     - main
-    - release*
+    - release-*
 
 permissions:
   contents: read
@@ -43,6 +43,7 @@ jobs:
         make lint
 
   ci-validate-manifests:
+    if: false
     name: ci-validate-manifests
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +78,7 @@ jobs:
         make validate-modules
 
   ci-validate-docs:
+    if: false
     name: ci-validate-docs
     runs-on: ubuntu-latest
     steps:
@@ -154,6 +156,7 @@ jobs:
         EOL
 
   ci-benchmark-tests-release:
+    if: false
     name: ci-benchmark-tests-releasebranch
     runs-on: ubuntu-latest
     steps:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -3,7 +3,8 @@
     "**/*.md"
   ],
   "ignores": [
-    "vendor/**"
+    "vendor/**",
+    ".cve-fix/**"
   ],
   // ToDo: Following rules can't be fixed automatically. They should be enabled when fixed.
   "config": {


### PR DESCRIPTION
This is a backport of https://github.com/stolostron/kube-state-metrics/pull/265 , which adds e2e testing support for kube-state-metrics through Github Actions.